### PR TITLE
Add missing linked list menu in directory

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -1,5 +1,4 @@
 
-
 ## Arithmetic Analysis
 
 ## Backtracking
@@ -17,6 +16,7 @@
 ## Data Structures
   * Linked List
     * [Singly Linked List](https://github.com/TheAlgorithms/Elixir/blob/master/lib/data_structures/singly_linked_list.ex)
+    * [Doubly Linked List](https://github.com/TheAlgorithms/Elixir/blob/master/lib/data_structures/doubly_linked_list.ex)
 
 ## Digital Image Processing
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg?logo=paypal&style=flat-square)](https://www.paypal.me/TheAlgorithms/100)&nbsp;
 [![Gitter chat](https://img.shields.io/badge/Chat-Gitter-ff69b4.svg?label=Chat&logo=gitter&style=flat-square)](https://gitter.im/TheAlgorithms)&nbsp;
 
-
 ### All algorithms implemented in Elixir (for education)
 
 These implementations are for learning purposes. They may be less efficient than the implementations in the Elixir standard library.
@@ -12,8 +11,7 @@ These implementations are for learning purposes. They may be less efficient than
 
 Read our [Contribution Guidelines](CONTRIBUTING.md) before you contribute.
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm).
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc) and published on [HexDocs](https://hexdocs.pm).
 
 ## Community Channel
 


### PR DESCRIPTION
I noticed that the `Doubly Linked List` wasn't added to the Directory file.