### PR TITLE
Rename project to fix typo

### DIFF
--- a/lib/algorithims.ex
+++ b/lib/algorithims.ex
@@ -1,6 +1,6 @@
-defmodule Algorithims do
+defmodule Algorithms do
   @moduledoc """
-  Documentation for Algorithims.
+  Documentation for Algorithms.
   """
 
   @doc """
@@ -8,7 +8,7 @@ defmodule Algorithims do
 
   ## Examples
 
-      iex> Algorithims.hello()
+      iex> Algorithms.hello()
       :world
 
   """

--- a/lib/data_structures/doubly_linked_list.ex
+++ b/lib/data_structures/doubly_linked_list.ex
@@ -1,4 +1,4 @@
-defmodule Algorithims.DataStructures.DoublyLinkedList do
+defmodule Algorithms.DataStructures.DoublyLinkedList do
   @moduledoc """
   Because of elixir's immutability, there is no true way of having fully cyclical, referential structures. You would have to make a copy of the list with each change, and account for the new reference.
   We will not write overly complex code to do that, and allow the user to understand the nuance here.

--- a/lib/data_structures/singly_linked_list.ex
+++ b/lib/data_structures/singly_linked_list.ex
@@ -1,4 +1,4 @@
-defmodule Algorithims.DataStructures.SinglyLinkedList do
+defmodule Algorithms.DataStructures.SinglyLinkedList do
   @moduledoc """
   Access for SinglyLinkedList is O(n)
   Search for SinglyLinkedList is O(n)

--- a/mix.exs
+++ b/mix.exs
@@ -1,9 +1,9 @@
-defmodule Algorithims.MixProject do
+defmodule Algorithms.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :algorithims,
+      app: :algorithms,
       version: "0.1.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,

--- a/test/algorithims_test.exs
+++ b/test/algorithims_test.exs
@@ -1,8 +1,8 @@
-defmodule AlgorithimsTest do
+defmodule AlgorithmsTest do
   use ExUnit.Case
-  doctest Algorithims
+  doctest Algorithms
 
   test "greets the world" do
-    assert Algorithims.hello() == :world
+    assert Algorithms.hello() == :world
   end
 end

--- a/test/data_structures/doubly_linked_list_test.exs
+++ b/test/data_structures/doubly_linked_list_test.exs
@@ -1,10 +1,10 @@
-defmodule Algorithims.DataStructures.DoublyLinkedListTest do
-  alias Algorithims.DataStructures.DoublyLinkedList
+defmodule Algorithms.DataStructures.DoublyLinkedListTest do
+  alias Algorithms.DataStructures.DoublyLinkedList
   alias DoublyLinkedList.LinkedList
   alias DoublyLinkedList.Node
 
   use ExUnit.Case
-  doctest Algorithims
+  doctest Algorithms
 
   describe "get_node/1" do
     test "it works when the list is empty" do

--- a/test/data_structures/singly_linked_list_test.exs
+++ b/test/data_structures/singly_linked_list_test.exs
@@ -1,10 +1,10 @@
-defmodule Algorithims.DataStructures.SinglyLinkedListTest do
-  alias Algorithims.DataStructures.SinglyLinkedList
+defmodule Algorithms.DataStructures.SinglyLinkedListTest do
+  alias Algorithms.DataStructures.SinglyLinkedList
   alias SinglyLinkedList.LinkedList
   alias SinglyLinkedList.Node
 
   use ExUnit.Case
-  doctest Algorithims
+  doctest Algorithms
 
   describe "add_node_head/2" do
     test "it works when the list is empty" do


### PR DESCRIPTION
The project name has a typo. It should be `Algorithms` instead of `Algorithims`.